### PR TITLE
Multi-gpu support, correct cuda stream usage in simple fft interface

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,9 @@ Version 2023.1.X (2023-XX-XX)
 -----------------------------
 * Add pyvkfft-benchmark script.
 * Add ability to automatically download VkFFT.h for a given version or git tag.
+* Actually use cuda_stream parameter in the pyvkfft.fft interface
+* Take into account current cuda device when automatically
+  caching VkFFTApp using the pyvkfft.fft interface(#26)
 
 Version 2023.1.1 (2023-01-22)
 -----------------------------

--- a/pyvkfft/accuracy.py
+++ b/pyvkfft/accuracy.py
@@ -60,7 +60,7 @@ except ImportError:
     has_cupy = False
     has_pycuda = False
 
-# Dictionnary of cuda/opencl (device, context). Will be initialised on-demand.
+# Dictionary of cuda/opencl (device, context). Will be initialised on-demand.
 # This is needed for multiprocessing.
 # The pyopencl entry is a tuple with (device, context, queue, has_cl_fp64)
 gpu_ctx_dic = {}

--- a/pyvkfft/fft.py
+++ b/pyvkfft/fft.py
@@ -96,7 +96,8 @@ def _prepare_transform(src, dest, cl_queue, cuda_stream, r2c=False):
                 else:
                     dest = cua.empty_like(src)
             dest_ptr = int(dest.gpudata)
-            devctx = cu_drv.Context.handle
+            if cuda_stream is None:
+                devctx = cu_drv.Context.get_current()
 
     if backend == Backend.UNKNOWN and has_opencl:
         if isinstance(src, cla.Array):


### PR DESCRIPTION
* Take into account the current cuda device when automatically caching the VkFFTApp using the pyvkfft.fft interface (closes #26).
* Actually use the cuda_stream parameter in the pyvkfft.fft interface.
* Prevent F-ordered inplace R2C tests with cupy
