### PR TITLE
Add (some) support for numpy 2.0

### DIFF
--- a/pyvkfft/accuracy.py
+++ b/pyvkfft/accuracy.py
@@ -292,10 +292,11 @@ def test_accuracy(backend, shape, ndim, axes, dtype, inplace, norm, use_lut,
         else:
             d0 = init_array.astype(dtype)
     else:
+        rng = np.random.default_rng(seed=None)
         if r2c or dct or dst:
-            d0 = np.random.uniform(-0.5, 0.5, shape).astype(dtypef)
+            d0 = rng.uniform(-0.5, 0.5, size=shape).astype(dtypef)
         else:
-            d0 = (np.random.uniform(-0.5, 0.5, shape) + 1j * np.random.uniform(-0.5, 0.5, shape)).astype(dtype)
+            d0 = (rng.uniform(-0.5, 0.5, size=shape) + 1j * rng.uniform(-0.5, 0.5, size=shape)).astype(dtype)
 
     if order != 'C':
         d0 = np.asarray(d0, order=order)

--- a/pyvkfft/accuracy.py
+++ b/pyvkfft/accuracy.py
@@ -655,4 +655,4 @@ def exhaustive_test(backend, vn, ndim, dtype, inplace, norm, use_lut, r2c=False,
                 vres.append(res)
     if return_res:
         return vres
-    return np.alltrue(vok)
+    return np.all(vok)

--- a/pyvkfft/base.py
+++ b/pyvkfft/base.py
@@ -387,7 +387,7 @@ def calc_transform_axes(shape, axes=None, ndim=None, strides=None):
         # Try with shape=(3,1), F and C-ordered as a corner case...
         s0 = strides_nonzero(strides)
         reorder_shape, reorder_axes = False, False
-        if not np.alltrue([s0[i] >= s0[i + 1] for i in range(n - 1)]):
+        if not np.all([s0[i] >= s0[i + 1] for i in range(n - 1)]):
             # Array is F-ordered, need to reorder shape & axes
             if axes is None:
                 # Using ndim, so axes1 is already OK
@@ -408,7 +408,7 @@ def calc_transform_axes(shape, axes=None, ndim=None, strides=None):
     for i in axes1:
         skip_axis[i] = False
 
-    if np.alltrue([shape1[ax] == 1 for ax in axes1]):
+    if np.all([shape1[ax] == 1 for ax in axes1]):
         raise RuntimeError(f"No axis is actually transformed: shape={shape} ndim={ndim} "
                            f"axes={axes} strides={strides} vkfft_shape={shape1} "
                            f"vkfft_axes={axes1} vkfft_skip={skip_axis}")
@@ -601,7 +601,7 @@ class VkFFTApp:
                 self.fast_axis = axes[-1]
             else:
                 s0 = strides_nonzero(strides)
-                if not np.alltrue([s0[i] >= s0[i + 1] for i in range(len(shape) - 1)]):
+                if not np.all([s0[i] >= s0[i + 1] for i in range(len(shape) - 1)]):
                     # F-ordered array
                     self.fast_axis = 0
         if r2c and axes is not None:

--- a/pyvkfft/test/test_fft.py
+++ b/pyvkfft/test/test_fft.py
@@ -28,7 +28,8 @@ except ImportError:
         from scipy.misc import ascent
     except ImportError:
         def ascent():
-            return np.random.randint(0, 255, (512, 512))
+            rng = np.random.default_rng(seed=None)
+            return rng.integers(0, 255, size=(512, 512))
 
 from pyvkfft.version import __version__, vkfft_version, vkfft_git_version
 from pyvkfft.base import primes, radix_gen_n
@@ -360,6 +361,8 @@ class TestFFT(unittest.TestCase):
                   "   type      lut?    inplace?      norm  C/F  FFT: L2 error     Linf"
                   "       < max  (Linf/max) unchanged? iFFT: L2   Linf      < max"
                   "  (Linf/max) unchanged? buffer status")
+
+        rng = np.random.default_rng(seed=None)
         for backend in vbackend:
             # We assume the context was already initialised by the calling function
             # init_ctx(backend, gpu_name=self.gpu, opencl_platform=self.opencl_platform, verbose=False)
@@ -404,10 +407,10 @@ class TestFFT(unittest.TestCase):
 
                                 if not dry_run:
                                     if dtype in (np.float32, np.float64):
-                                        d0 = np.random.uniform(-0.5, 0.5, vsh[0]).astype(dtype)
+                                        d0 = rng.uniform(-0.5, 0.5, size=vsh[0]).astype(dtype)
                                     else:
-                                        d0 = (np.random.uniform(-0.5, 0.5, vsh[0])
-                                              + 1j * np.random.uniform(-0.5, 0.5, vsh[0])).astype(dtype)
+                                        d0 = (rng.uniform(-0.5, 0.5, size=vsh[0])
+                                              + 1j * rng.uniform(-0.5, 0.5, size=vsh[0])).astype(dtype)
                                 if vlut == "auto":
                                     if dtype in (np.float64, np.complex128):
                                         # By default, LUT is enabled for complex128, no need to test twice
@@ -719,6 +722,8 @@ class TestFFT(unittest.TestCase):
         """
         Test multiple FFT in // with different cuda streams.
         """
+        rng = np.random.default_rng(seed=None)
+
         for dtype in (np.complex64, np.complex128):
             with self.subTest(dtype=np.dtype(dtype)):
                 init_ctx("pycuda", gpu_name=self.gpu, opencl_platform=self.opencl_platform, verbose=False)
@@ -727,7 +732,7 @@ class TestFFT(unittest.TestCase):
                 else:
                     rtol = 1e-12
                 sh = (256, 256)
-                d = (np.random.uniform(-0.5, 0.5, sh) + 1j * np.random.uniform(-0.5, 0.5, sh)).astype(dtype)
+                d = (rng.uniform(-0.5, 0.5, size=sh) + 1j * rng.uniform(-0.5, 0.5, size=sh)).astype(dtype)
                 n_streams = 5
                 vd = []
                 vapp = []
@@ -761,6 +766,7 @@ class TestFFT(unittest.TestCase):
         # Disable warning
         old_warning = pyvkfft.config.WARN_OPENCL_QUEUE_MISMATCH
         pyvkfft.config.WARN_OPENCL_QUEUE_MISMATCH = False
+        rng = np.random.default_rng(seed=None)
         for dtype in vtype:
             with self.subTest(dtype=np.dtype(dtype)):
                 init_ctx("pyopencl", gpu_name=self.gpu, opencl_platform=self.opencl_platform, verbose=False)
@@ -770,7 +776,7 @@ class TestFFT(unittest.TestCase):
                 else:
                     rtol = 1e-12
                 sh = (256, 256)
-                d = (np.random.uniform(-0.5, 0.5, sh) + 1j * np.random.uniform(-0.5, 0.5, sh)).astype(dtype)
+                d = (rng.uniform(-0.5, 0.5, size=sh) + 1j * rng.uniform(-0.5, 0.5, size=sh)).astype(dtype)
                 n_queues = 5
                 vd = []
                 vapp = []
@@ -1042,11 +1048,12 @@ class TestFFTSystematic(unittest.TestCase):
             return
         # Generate the list of configurations as kwargs for test_accuracy()
         vkwargs = []
+        rng = np.random.default_rng(seed=None)
         for backend in self.vbackend:
             for s in self.vshape:
                 if self.fast_random is not None and len(vkwargs):
                     # Randomly skip tests to go faster
-                    if np.random.uniform(0, 100) > self.fast_random:
+                    if rng.uniform(0, 100) > self.fast_random:
                         continue
                 kwargs = {"backend": backend, "shape": s, "ndim": len(s), "axes": self.axes,
                           "dtype": self.dtype, "inplace": self.inplace, "norm": self.norm, "use_lut": self.lut,

--- a/pyvkfft/test/test_fft.py
+++ b/pyvkfft/test/test_fft.py
@@ -278,14 +278,14 @@ class TestFFT(unittest.TestCase):
                     axes = [-ax - 1 for ax in axes]
                 # Make sure at least one transformed axis has a length>1
                 if axes is not None:
-                    if np.alltrue([sh[ax] == 1 for ax in axes]):
+                    if np.all([sh[ax] == 1 for ax in axes]):
                         continue
                 else:
                     if order == 'C':
-                        if np.alltrue([sh[-i] == 1 for i in range(ndim)]):
+                        if np.all([sh[-i] == 1 for i in range(ndim)]):
                             continue
                     else:
-                        if np.alltrue([sh[i] == 1 for i in range(ndim)]):
+                        if np.all([sh[i] == 1 for i in range(ndim)]):
                             continue
                 if r2c and axes is None and np.sum([s == 1 for s in sh]) == 1 and len(sh) > 1:
                     # Without axes, if only one has a length>1, the fast


### PR DESCRIPTION
I'm not sure this is all there is to fix, but it seems to work for me: the project builds and the tests run (haven't ran all of them, I think).

The main changes are:
* replaced `np.alltrue` with `np.all`: `np.alltrue` was deprecated in 1.25 and removed in numpy 2.0
* replaced `np.random.uniform` with `Genenerator.uniform`: these are not removed, but numpy heavily recommends using the `Generator` interface these days.